### PR TITLE
bug fix

### DIFF
--- a/app/src/main/java/moe/haruue/wadb/WadbPreferences.java
+++ b/app/src/main/java/moe/haruue/wadb/WadbPreferences.java
@@ -4,6 +4,7 @@ public class WadbPreferences {
 
     public static final String KEY_WAKE_PORT = "pref_key_wadb_port";
     public static final String KEY_WAKE_LOCK = "pref_key_wake_lock";
+    public static final String KEY_SCREEN_LOCK_SWITCH = "pref_key_screen_lock_switch";
     public static final String KEY_NOTIFICATION = "pref_key_notification";
     public static final String KEY_NOTIFICATION_LOW_PRIORITY = "pref_key_notification_low_priority";
     public static final String KEY_LAUNCHER_ICONS = "pref_key_hide_launcher_icon";

--- a/app/src/main/java/moe/haruue/wadb/component/home/HomeFragment.java
+++ b/app/src/main/java/moe/haruue/wadb/component/home/HomeFragment.java
@@ -26,6 +26,7 @@ import moe.haruue.wadb.events.WadbStateChangedEvent;
 import moe.haruue.wadb.util.NetworksUtils;
 import moe.haruue.wadb.util.NotificationHelper;
 import moe.haruue.wadb.util.ScreenKeeper;
+import moe.shizuku.preference.CheckBoxPreference;
 import moe.shizuku.preference.EditTextPreference;
 import moe.shizuku.preference.PreferenceFragment;
 import moe.shizuku.preference.TwoStatePreference;
@@ -94,13 +95,18 @@ public class HomeFragment extends PreferenceFragment implements WadbStateChanged
 
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
-        addPreferencesFromResource(R.xml.preferences);
         getPreferenceManager().setStorageDeviceProtected();
+        addPreferencesFromResource(R.xml.preferences);
         getPreferenceManager().setSharedPreferencesName(WadbApplication.getDefaultSharedPreferenceName());
 
         final Context context = requireContext();
         switchPreference = (TwoStatePreference) findPreference(KEY_WADB_SWITCH);
         portPreference = (EditTextPreference) findPreference(KEY_WAKE_PORT);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            CheckBoxPreference checkBoxPreference = (CheckBoxPreference) findPreference(KEY_NOTIFICATION_LOW_PRIORITY);
+            checkBoxPreference.setVisible(false);
+        }
 
         TwoStatePreference launcherIconPreference = (TwoStatePreference) findPreference(KEY_LAUNCHER_ICONS);
         launcherIconPreference.setChecked(!WadbApplication.isLauncherActivityEnabled(context));

--- a/app/src/main/java/moe/haruue/wadb/service/WadbTileService.java
+++ b/app/src/main/java/moe/haruue/wadb/service/WadbTileService.java
@@ -11,6 +11,7 @@ import androidx.annotation.RequiresApi;
 
 import moe.haruue.wadb.R;
 import moe.haruue.wadb.WadbApplication;
+import moe.haruue.wadb.WadbPreferences;
 import moe.haruue.wadb.events.Events;
 import moe.haruue.wadb.events.GlobalRequestHandler;
 import moe.haruue.wadb.events.WadbStateChangedEvent;
@@ -60,7 +61,7 @@ public abstract class WadbTileService extends TileService implements WadbStateCh
         super.onClick();
 
         Log.d(TAG, "onClick");
-        boolean enableScreenLockSwitch = WadbApplication.getDefaultSharedPreferences().getBoolean("pref_key_screen_lock_switch", false);
+        boolean enableScreenLockSwitch = WadbApplication.getDefaultSharedPreferences().getBoolean(WadbPreferences.KEY_SCREEN_LOCK_SWITCH, false);
         if (getQsTile().getState() == Tile.STATE_ACTIVE) {
             if (enableScreenLockSwitch) {
                 STOP_WADB.run();

--- a/app/src/main/java/moe/haruue/wadb/util/NotificationHelper.java
+++ b/app/src/main/java/moe/haruue/wadb/util/NotificationHelper.java
@@ -35,6 +35,8 @@ public class NotificationHelper {
         turnOffIntent.setComponent(new ComponentName(context, TurnOffReceiver.class));
         PendingIntent turnOffPendingIntent = PendingIntent.getBroadcast(context, 0, turnOffIntent, 0);
         Notification.Action turnOffAction = new Notification.Action.Builder(Icon.createWithResource(context, R.drawable.ic_close_white_24dp), context.getString(R.string.turn_off), turnOffPendingIntent).build();
+        int visibility = WadbApplication.getDefaultSharedPreferences().getBoolean(WadbPreferences.KEY_SCREEN_LOCK_SWITCH, false) ?
+                Notification.VISIBILITY_PUBLIC : Notification.VISIBILITY_PRIVATE;
 
         // Android Q supports dark status bar, but still uses color restriction algorithm of light background,
         // so we still have to use light color here
@@ -53,6 +55,7 @@ public class NotificationHelper {
                 .setSmallIcon(R.drawable.ic_qs_network_adb_on)
                 .setContentIntent(contentPendingIntent)
                 .addAction(turnOffAction)
+                .setVisibility(visibility)
                 .setColor(color)
                 .setOngoing(true);
 

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -32,6 +32,14 @@
             android:summaryOn="@string/show_notification_when_wadb_on"
             android:title="@string/notification" />
 
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="pref_key_notification_low_priority"
+            android:dependency="pref_key_notification"
+            android:summaryOff="@string/use_default_priority_notification"
+            android:summaryOn="@string/use_low_priority_notification"
+            android:title="@string/low_priority_notification"/>
+
         <Preference
             android:summary="@string/notification_settings_summary"
             android:title="@string/notification_settings">


### PR DESCRIPTION
`getPreferenceManager().setStorageDeviceProtected()`应首先执行，否则无法保存设置。